### PR TITLE
Update pgbench_script.sh - Issue #2

### DIFF
--- a/postgresql/pgbench_script.sh
+++ b/postgresql/pgbench_script.sh
@@ -1,7 +1,7 @@
  #!/bin/bash
 
 KUBECTL=/usr/bin/kubectl
-PGPASSWORD=$($KUBECTL get secret --namespace default ${1}-postgresql -o jsonpath="{.data.postgres-password}" | base64 --decode; echo)
+PGPASSWORD=$($KUBECTL get secret --namespace default ${1}-postgresql -o jsonpath="{.data.postgresql-password}" | base64 --decode; echo)
 
 function usage() {
 	echo "Usage: $0 <release-name> <init [scaling-factor] | bench [transactions] [clients] | shell | kill-and-move>"


### PR DESCRIPTION
Resolves [Issue #2](https://github.com/VxFlex-OS/kubernetes-demo-scripts/issues/2).

After change to [stable/postgresql] chart in commit https://github.com/helm/charts/commit/7f1e47c5a8b10f24547aa385d782294622f8f439 the format is now `.data.postgresql-password` (changed from `.data.postgres-password`). Updating pg_bench.sh to look for `PGPASSWORD` the correct field in the secret.